### PR TITLE
FIX: defining _DEFAULT_SOURCE on linux platforms to support strsep()

### DIFF
--- a/src/lib/ircbot/ircchannel.c
+++ b/src/lib/ircbot/ircchannel.c
@@ -1,3 +1,6 @@
+#ifdef __linux__
+#define _DEFAULT_SOURCE /* strsep(): this is needed with glibc on linux */
+#endif
 #include <ircbot/hashtable.h>
 #include <ircbot/irccommand.h>
 

--- a/src/lib/ircbot/ircchannel.c
+++ b/src/lib/ircbot/ircchannel.c
@@ -1,6 +1,4 @@
-#ifdef __linux__
-#define _DEFAULT_SOURCE /* strsep(): this is needed with glibc on linux */
-#endif
+#define _DEFAULT_SOURCE
 #include <ircbot/hashtable.h>
 #include <ircbot/irccommand.h>
 

--- a/src/lib/ircbot/ircmessage.c
+++ b/src/lib/ircbot/ircmessage.c
@@ -1,6 +1,4 @@
-#ifdef __linux__
-#define _DEFAULT_SOURCE /* strsep(): this is needed with glibc on linux */
-#endif
+#define _DEFAULT_SOURCE
 #include <ircbot/irccommand.h>
 #include <ircbot/list.h>
 #include <ircbot/log.h>

--- a/src/lib/ircbot/ircmessage.c
+++ b/src/lib/ircbot/ircmessage.c
@@ -1,3 +1,6 @@
+#ifdef __linux__
+#define _DEFAULT_SOURCE /* strsep(): this is needed with glibc on linux */
+#endif
 #include <ircbot/irccommand.h>
 #include <ircbot/list.h>
 #include <ircbot/log.h>

--- a/src/lib/ircbot/list.c
+++ b/src/lib/ircbot/list.c
@@ -1,6 +1,4 @@
-#ifdef __linux__
-#define _DEFAULT_SOURCE /* strsep(): this is needed with glibc on linux */
-#endif
+#define _DEFAULT_SOURCE
 #include <ircbot/list.h>
 
 #include "util.h"

--- a/src/lib/ircbot/list.c
+++ b/src/lib/ircbot/list.c
@@ -1,3 +1,6 @@
+#ifdef __linux__
+#define _DEFAULT_SOURCE /* strsep(): this is needed with glibc on linux */
+#endif
 #include <ircbot/list.h>
 
 #include "util.h"


### PR DESCRIPTION
GCC complains about undefined functions without the correct feature macro present. This fixes running into an error on linux systems. Currently, this only affects strsep().

Tested on Debian 11 (Bullseye) amd64 - No virtualization.